### PR TITLE
Rework pose estimation

### DIFF
--- a/src/main/java/frc/robot/commands/AutoBargeAlignCommand.java
+++ b/src/main/java/frc/robot/commands/AutoBargeAlignCommand.java
@@ -13,13 +13,11 @@ import edu.wpi.first.math.controller.ProfiledPIDController;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Transform2d;
-import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import edu.wpi.first.units.measure.AngularAcceleration;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.LinearAcceleration;
 import edu.wpi.first.units.measure.LinearVelocity;
-import edu.wpi.first.wpilibj.DataLogManager;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.subsystems.CommandSwerveDrivetrain;
 import frc.robot.utils.AllianceFlipUtil;
@@ -66,7 +64,9 @@ public class AutoBargeAlignCommand extends Command {
   @Override
   public void initialize() {
     Pose2d currentPose = drivetrain.getState().Pose;
-    Pose2d targetPose = AllianceFlipUtil.apply(BLUE_SCORE_POSE).plus(new Transform2d(0, currentPose.getX(), Rotation2d.kZero));
+    Pose2d targetPose =
+        AllianceFlipUtil.apply(BLUE_SCORE_POSE)
+            .plus(new Transform2d(0, currentPose.getX(), Rotation2d.kZero));
 
     xController.setGoal(targetPose.getX());
     thetaController.setGoal(targetPose.getRotation().getRadians());

--- a/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
+++ b/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
@@ -17,9 +17,12 @@ import com.pathplanner.lib.controllers.PPHolonomicDriveController;
 import com.pathplanner.lib.util.DriveFeedforwards;
 import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.epilogue.Logged.Importance;
+import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import edu.wpi.first.math.numbers.N1;
+import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
 import edu.wpi.first.wpilibj.Notifier;
@@ -173,7 +176,7 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain
     List<EstimatedRobotPose> estimatedPoses = vision.getEstimatedGlobalPoses();
 
     for (EstimatedRobotPose estimatedPose : estimatedPoses) {
-      addVisionMeasurement(estimatedPose);
+      addVisionMeasurement(estimatedPose, vision.getEstimationStdDevs());
     }
   }
 
@@ -182,10 +185,11 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain
    *
    * @param estimatedRobotPose The estimated robot pose from vision processing.
    */
-  public void addVisionMeasurement(EstimatedRobotPose estimatedRobotPose) {
+  public void addVisionMeasurement(EstimatedRobotPose estimatedRobotPose, Matrix<N3, N1> stdDevs) {
     Pose2d estPose = estimatedRobotPose.estimatedPose.toPose2d();
 
-    addVisionMeasurement(estPose, Utils.fpgaToCurrentTime(estimatedRobotPose.timestampSeconds));
+    addVisionMeasurement(
+        estPose, Utils.fpgaToCurrentTime(estimatedRobotPose.timestampSeconds), stdDevs);
   }
 
   private void configureAutoBuilder() {


### PR DESCRIPTION
Previously, we only used the latest results from each photon camera. 
This commit changes the logic to use all unread results while also integrating standard deviations.

Should deploy then see if it helps with pose estimation.